### PR TITLE
feat: Phase 1 — harness abstraction layer foundation

### DIFF
--- a/src/harness/fs-utils.mjs
+++ b/src/harness/fs-utils.mjs
@@ -1,0 +1,240 @@
+import { access, open, readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Check whether a path exists.
+ *
+ * @param {string} p
+ * @returns {Promise<boolean>}
+ */
+export async function exists(p) {
+  try { await access(p); return true; } catch { return false; }
+}
+
+/**
+ * Read a file and return null when it cannot be read.
+ *
+ * @param {string} p
+ * @param {BufferEncoding} [encoding]
+ * @returns {Promise<string|null>}
+ */
+export async function safeReadFile(p, encoding = "utf-8") {
+  try { return await readFile(p, encoding); } catch { return null; }
+}
+
+/**
+ * Stat a path and return null when it cannot be read.
+ *
+ * @param {string} p
+ * @returns {Promise<import("node:fs").Stats|null>}
+ */
+export async function safeStat(p) {
+  try { return await stat(p); } catch { return null; }
+}
+
+function countNewlines(buffer) {
+  let count = 0;
+  for (const byte of buffer) {
+    if (byte === 10) count++;
+  }
+  return count;
+}
+
+/**
+ * Read the first n lines without loading the whole file.
+ *
+ * @param {string} p
+ * @param {number} maxLines
+ * @param {number} [chunkSize]
+ * @returns {Promise<string[]>}
+ */
+export async function readFirstLines(p, maxLines, chunkSize = 8192) {
+  let handle;
+  try {
+    handle = await open(p, "r");
+    const chunks = [];
+    let position = 0;
+    let newlineCount = 0;
+
+    while (newlineCount < maxLines) {
+      const buffer = Buffer.alloc(chunkSize);
+      const { bytesRead } = await handle.read(buffer, 0, chunkSize, position);
+      if (!bytesRead) break;
+      const chunk = buffer.subarray(0, bytesRead);
+      chunks.push(chunk);
+      position += bytesRead;
+      newlineCount += countNewlines(chunk);
+    }
+
+    return Buffer.concat(chunks).toString("utf-8").split(/\r?\n/).slice(0, maxLines);
+  } catch {
+    return [];
+  } finally {
+    if (handle) await handle.close();
+  }
+}
+
+/**
+ * Read the last n lines without loading the whole file.
+ *
+ * @param {string} p
+ * @param {number} maxLines
+ * @param {number} [fileSize]
+ * @param {number} [chunkSize]
+ * @returns {Promise<string[]>}
+ */
+export async function readLastLines(p, maxLines, fileSize, chunkSize = 8192) {
+  const size = fileSize ?? (await safeStat(p))?.size ?? 0;
+  if (!size) return [];
+
+  let handle;
+  try {
+    handle = await open(p, "r");
+    const chunks = [];
+    let position = size;
+    let newlineCount = 0;
+
+    while (position > 0 && newlineCount < maxLines) {
+      const start = Math.max(0, position - chunkSize);
+      const length = position - start;
+      const buffer = Buffer.alloc(length);
+      const { bytesRead } = await handle.read(buffer, 0, length, start);
+      if (!bytesRead) break;
+      const chunk = buffer.subarray(0, bytesRead);
+      chunks.unshift(chunk);
+      position = start;
+      newlineCount += countNewlines(chunk);
+    }
+
+    const lines = Buffer.concat(chunks).toString("utf-8").split(/\r?\n/);
+    if (lines.at(-1) === "") lines.pop();
+    return lines.slice(-maxLines);
+  } catch {
+    return [];
+  } finally {
+    if (handle) await handle.close();
+  }
+}
+
+/**
+ * Parse one JSONL record.
+ *
+ * @param {string} line
+ * @returns {*|null}
+ */
+export function parseJsonLine(line) {
+  try { return JSON.parse(line); } catch { return null; }
+}
+
+/**
+ * Format bytes using the same compact labels as scanner.mjs.
+ *
+ * @param {number} bytes
+ * @returns {string}
+ */
+export function formatSize(bytes) {
+  if (!bytes) return "0B";
+  if (bytes < 1024) return bytes + "B";
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + "K";
+  if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + "MB";
+  return (bytes / (1024 * 1024 * 1024)).toFixed(1) + "GB";
+}
+
+/**
+ * Extract simple YAML frontmatter key/value pairs from markdown.
+ *
+ * @param {string|null} content
+ * @returns {Record<string, string>}
+ */
+export function parseFrontmatter(content) {
+  if (!content) return {};
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const fm = {};
+  for (const line of match[1].split("\n")) {
+    const m = line.match(/^(\w+):\s*(.+)/);
+    if (m) fm[m[1]] = m[2].trim();
+  }
+  return fm;
+}
+
+/**
+ * Safely parse a JSON file.
+ *
+ * @param {string} p
+ * @returns {Promise<*|null>}
+ */
+export async function readJson(p) {
+  const content = await safeReadFile(p);
+  if (!content) return null;
+  try { return JSON.parse(content); } catch { return null; }
+}
+
+/**
+ * Scan one directory for markdown files.
+ *
+ * @param {string} dir
+ * @returns {Promise<Array<{ name: string, path: string, content: string, frontmatter: Record<string, string>, size: string, mtime: string }>>}
+ */
+export async function scanMarkdownFiles(dir) {
+  const items = [];
+  if (!(await exists(dir))) return items;
+
+  let files;
+  try { files = await readdir(dir); } catch { return items; }
+
+  for (const f of files) {
+    if (!f.endsWith(".md")) continue;
+    const fullPath = join(dir, f);
+    const s = await safeStat(fullPath);
+    const content = await safeReadFile(fullPath) || "";
+    items.push({
+      name: parseFrontmatter(content).name || f.replace(".md", ""),
+      path: fullPath,
+      content,
+      frontmatter: parseFrontmatter(content),
+      size: s ? formatSize(s.size) : "0B",
+      mtime: s ? s.mtime.toISOString().slice(0, 16) : "",
+    });
+  }
+
+  return items;
+}
+
+function matchesPattern(fileName, pattern) {
+  if (!pattern) return true;
+  if (pattern instanceof RegExp) return pattern.test(fileName);
+  if (typeof pattern === "function") return pattern(fileName);
+  if (typeof pattern === "string") return fileName.endsWith(pattern);
+  return false;
+}
+
+/**
+ * Scan one directory for files matching a suffix, RegExp, or predicate.
+ *
+ * @param {string} dir
+ * @param {string|RegExp|((fileName: string) => boolean)} [pattern]
+ * @returns {Promise<Array<{ name: string, path: string, size: string, sizeBytes: number, mtime: string }>>}
+ */
+export async function scanDirectoryItems(dir, pattern) {
+  const items = [];
+  if (!(await exists(dir))) return items;
+
+  let entries;
+  try { entries = await readdir(dir, { withFileTypes: true }); } catch { return items; }
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !matchesPattern(entry.name, pattern)) continue;
+    const fullPath = join(dir, entry.name);
+    const s = await safeStat(fullPath);
+    items.push({
+      name: entry.name,
+      path: fullPath,
+      size: s ? formatSize(s.size) : "0B",
+      sizeBytes: s ? s.size : 0,
+      mtime: s ? s.mtime.toISOString().slice(0, 16) : "",
+    });
+  }
+
+  return items;
+}

--- a/src/harness/interface.mjs
+++ b/src/harness/interface.mjs
@@ -1,0 +1,227 @@
+/**
+ * Harness adapter interface contract.
+ *
+ * These typedefs describe the stable shape shared by harness adapters,
+ * scanners, UI routes, and operations. They intentionally preserve the
+ * existing scanner.mjs scope/item fields so Phase 1 can layer on top of the
+ * current Claude Code data model without breaking callers.
+ */
+
+/** @typedef {string} CategoryId */
+/** @typedef {string} ScopeTypeId */
+
+/**
+ * @typedef {object} HarnessCapabilities
+ * @property {boolean} contextBudget
+ * @property {boolean} mcpControls
+ * @property {boolean} mcpPolicy
+ * @property {boolean} mcpSecurity
+ * @property {boolean} sessions
+ * @property {boolean} effective
+ * @property {boolean} backup
+ */
+
+/**
+ * @typedef {object} HarnessContext
+ * @property {string} harnessId
+ * @property {string} home
+ * @property {string} cwd
+ * @property {NodeJS.Platform} platform
+ * @property {NodeJS.ProcessEnv} env
+ * @property {Record<string, *>} options
+ * @property {typeof import("node:fs/promises")} fs
+ */
+
+/**
+ * @typedef {object} CategoryDef
+ * @property {CategoryId} id
+ * @property {string} label
+ * @property {string} filterLabel
+ * @property {string} icon
+ * @property {number} order
+ * @property {string} group
+ * @property {string} source
+ * @property {string} preview
+ * @property {boolean} movable
+ * @property {boolean} deletable
+ * @property {boolean} participatesInEffective
+ * @property {string} effectiveRule
+ * @property {string} sortDefault
+ */
+
+/**
+ * @typedef {object} ScopeTypeDef
+ * @property {ScopeTypeId} id
+ * @property {string} label
+ * @property {string} icon
+ * @property {boolean} isGlobal
+ */
+
+/**
+ * @typedef {object} HarnessScope
+ * @property {string} id
+ * @property {string} name
+ * @property {ScopeTypeId} type
+ * @property {string} tag
+ * @property {string|null} parentId
+ * @property {string|null} repoDir
+ * @property {string|null} configDir
+ * @property {Record<string, *>} [data]
+ * @property {string|null} [claudeProjectDir] Existing Claude scanner field.
+ */
+
+/**
+ * Existing scanner.mjs-compatible inventory item.
+ *
+ * @typedef {object} HarnessItem
+ * @property {CategoryId} category
+ * @property {string} scopeId
+ * @property {string} name
+ * @property {string} [fileName]
+ * @property {string} [description]
+ * @property {string} [subType]
+ * @property {string} [size]
+ * @property {number} [sizeBytes]
+ * @property {string} [mtime]
+ * @property {string} [ctime]
+ * @property {string} [path]
+ * @property {string} [openPath]
+ * @property {string} [previewPath]
+ * @property {boolean} [locked]
+ * @property {boolean} [movable]
+ * @property {boolean} [deletable]
+ * @property {string|null} [bundle]
+ * @property {*} [value]
+ * @property {string} [valueType]
+ * @property {string} [sourceFile]
+ * @property {string} [sourceTier]
+ * @property {string} [settingGroup]
+ * @property {Record<string, *>} [mcpConfig]
+ * @property {Record<string, *>} [data]
+ */
+
+/**
+ * @typedef {object} EffectiveModel
+ * @property {Record<string, *>[]} rules
+ * @property {CategoryId[]} includeGlobalCategories
+ * @property {boolean} shadowByName
+ * @property {boolean} conflictByName
+ * @property {CategoryId[]} ancestorCategories
+ */
+
+/**
+ * @typedef {object} PromptAction
+ * @property {string} id
+ * @property {string} icon
+ * @property {string} label
+ * @property {string} info
+ * @property {string} kind
+ * @property {string} template
+ * @property {string|Function} when
+ */
+
+/**
+ * @typedef {object} HarnessOperations
+ * @property {(item: HarnessItem, scopes: HarnessScope[]) => *} getValidDestinations
+ * @property {(item: HarnessItem, toScopeId: string, scopes: HarnessScope[]) => Promise<*>} moveItem
+ * @property {(item: HarnessItem, scopes: HarnessScope[]) => Promise<*>} deleteItem
+ * @property {(backupPath: string, options?: Record<string, *>) => Promise<*>} [restoreItem]
+ * @property {(entry: Record<string, *>, options?: Record<string, *>) => Promise<*>} [restoreMcpEntry]
+ */
+
+/**
+ * @typedef {object} HarnessDescriptor
+ * @property {string} id
+ * @property {string} displayName
+ * @property {string} shortName
+ * @property {string} icon
+ * @property {string} executable
+ */
+
+/**
+ * @typedef {object} ScanResult
+ * @property {HarnessDescriptor} harness
+ * @property {CategoryDef[]} categories
+ * @property {ScopeTypeDef[]} scopeTypes
+ * @property {HarnessCapabilities} capabilities
+ * @property {HarnessScope[]} scopes
+ * @property {HarnessItem[]} items
+ * @property {Record<string, number>} counts
+ * @property {EffectiveModel|null} effective
+ * @property {Array<string|Record<string, *>>} notices
+ * @property {Record<string, *>} adapterData
+ */
+
+/**
+ * @typedef {object} HarnessAdapter
+ * @property {string} id
+ * @property {string} displayName
+ * @property {string} shortName
+ * @property {string} icon
+ * @property {string} executable
+ * @property {CategoryDef[]} categories
+ * @property {ScopeTypeDef[]} scopeTypes
+ * @property {HarnessCapabilities} capabilities
+ * @property {(ctx: HarnessContext) => { rootDir: string, backupDir: string, safeRoots: string[] }} getPaths
+ * @property {(ctx: HarnessContext) => Promise<HarnessScope[]>} discoverScopes
+ * @property {Record<CategoryId, (scope: HarnessScope, ctx: HarnessContext) => Promise<HarnessItem[]>>} scanners
+ * @property {(ctx: HarnessContext) => Promise<HarnessItem[]>} [scanGlobalItems]
+ * @property {(ctx: HarnessContext) => Promise<void>|void} [beforeScan]
+ * @property {(ctx: HarnessContext, result: Partial<ScanResult>) => Promise<Record<string, *>|void>|Record<string, *>|void} [afterScan]
+ * @property {*} [effective]
+ * @property {*} [prompts]
+ * @property {*} [itemConfig]
+ * @property {*} [contextBudget]
+ * @property {*} [sessions]
+ * @property {*} [mcpControls]
+ * @property {*} [mcpPolicy]
+ * @property {*} [security]
+ * @property {HarnessOperations} [operations]
+ */
+
+const REQUIRED_ADAPTER_STRINGS = ["id", "displayName", "shortName", "icon", "executable"];
+const REQUIRED_CAPABILITIES = ["contextBudget", "mcpControls", "mcpPolicy", "mcpSecurity", "sessions", "effective", "backup"];
+
+function assertCondition(condition, message) {
+  if (!condition) throw new TypeError(`Invalid harness adapter: ${message}`);
+}
+
+/**
+ * Validate an adapter at registration/startup time.
+ *
+ * @param {HarnessAdapter} adapter
+ * @returns {HarnessAdapter}
+ */
+export function validateAdapter(adapter) {
+  assertCondition(adapter && typeof adapter === "object", "adapter must be an object");
+
+  for (const field of REQUIRED_ADAPTER_STRINGS) {
+    assertCondition(typeof adapter[field] === "string" && adapter[field].trim(), `${field} is required`);
+  }
+
+  assertCondition(Array.isArray(adapter.categories), "categories must be an array");
+  assertCondition(Array.isArray(adapter.scopeTypes), "scopeTypes must be an array");
+  assertCondition(adapter.capabilities && typeof adapter.capabilities === "object", "capabilities is required");
+
+  for (const field of REQUIRED_CAPABILITIES) {
+    assertCondition(typeof adapter.capabilities[field] === "boolean", `capabilities.${field} must be boolean`);
+  }
+
+  assertCondition(typeof adapter.getPaths === "function", "getPaths(ctx) is required");
+  assertCondition(typeof adapter.discoverScopes === "function", "discoverScopes(ctx) is required");
+  assertCondition(adapter.scanners && typeof adapter.scanners === "object", "scanners record is required");
+
+  for (const category of adapter.categories) {
+    assertCondition(category && typeof category.id === "string" && category.id.trim(), "each category needs an id");
+    assertCondition(typeof category.label === "string", `category ${category.id} needs a label`);
+    assertCondition(typeof adapter.scanners[category.id] === "function", `scanner for category ${category.id} is required`);
+  }
+
+  for (const scopeType of adapter.scopeTypes) {
+    assertCondition(scopeType && typeof scopeType.id === "string" && scopeType.id.trim(), "each scope type needs an id");
+    assertCondition(typeof scopeType.label === "string", `scope type ${scopeType.id} needs a label`);
+    assertCondition(typeof scopeType.isGlobal === "boolean", `scope type ${scopeType.id} needs isGlobal`);
+  }
+
+  return adapter;
+}

--- a/src/harness/registry.mjs
+++ b/src/harness/registry.mjs
@@ -1,0 +1,95 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { validateAdapter } from "./interface.mjs";
+
+const adapters = new Map();
+let discoveryPromise = null;
+
+function adapterSummary(adapter) {
+  return {
+    id: adapter.id,
+    displayName: adapter.displayName,
+    shortName: adapter.shortName,
+    icon: adapter.icon,
+  };
+}
+
+async function importAdapterModule(filePath) {
+  const mod = await import(pathToFileURL(filePath).href);
+  const candidates = [];
+
+  if (mod.default) candidates.push(mod.default);
+  if (mod.adapter) candidates.push(mod.adapter);
+  if (Array.isArray(mod.adapters)) candidates.push(...mod.adapters);
+
+  for (const candidate of candidates) {
+    registerAdapter(candidate);
+  }
+}
+
+async function discoverAdapters() {
+  const adaptersDir = join(import.meta.dirname, "adapters");
+
+  let entries;
+  try {
+    entries = await readdir(adaptersDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries
+      .filter(entry => entry.isFile() && entry.name.endsWith(".mjs"))
+      .map(entry => importAdapterModule(join(adaptersDir, entry.name)))
+  );
+}
+
+async function ensureDiscovered() {
+  if (!discoveryPromise) discoveryPromise = discoverAdapters();
+  await discoveryPromise;
+}
+
+/**
+ * Register one harness adapter.
+ *
+ * @param {import("./interface.mjs").HarnessAdapter} adapter
+ * @returns {import("./interface.mjs").HarnessAdapter}
+ */
+export function registerAdapter(adapter) {
+  const validated = validateAdapter(adapter);
+  adapters.set(validated.id, validated);
+  return validated;
+}
+
+/**
+ * Return a registered adapter by id.
+ *
+ * @param {string} id
+ * @returns {Promise<import("./interface.mjs").HarnessAdapter>}
+ */
+export async function getAdapter(id) {
+  await ensureDiscovered();
+  const adapter = adapters.get(id);
+  if (!adapter) throw new Error(`Unknown harness adapter: ${id}`);
+  return adapter;
+}
+
+/**
+ * List registered adapter descriptors.
+ *
+ * @returns {Promise<Array<{ id: string, displayName: string, shortName: string, icon: string }>>}
+ */
+export async function listAdapters() {
+  await ensureDiscovered();
+  return [...adapters.values()].map(adapterSummary);
+}
+
+/**
+ * Default harness adapter id.
+ *
+ * @returns {string}
+ */
+export function getDefaultAdapterId() {
+  return "claude";
+}

--- a/src/harness/scanner-framework.mjs
+++ b/src/harness/scanner-framework.mjs
@@ -1,0 +1,141 @@
+import * as fs from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { validateAdapter } from "./interface.mjs";
+
+/**
+ * Build the context object passed to every adapter hook and scanner.
+ *
+ * @param {import("./interface.mjs").HarnessAdapter} adapter
+ * @param {Record<string, *>} [options]
+ * @returns {import("./interface.mjs").HarnessContext}
+ */
+export function createHarnessContext(adapter, options = {}) {
+  return {
+    harnessId: adapter.id,
+    home: options.home || homedir(),
+    cwd: options.cwd || process.cwd(),
+    platform: options.platform || platform(),
+    env: options.env || process.env,
+    options,
+    fs: options.fs || fs,
+  };
+}
+
+/**
+ * Count scanned items by category.
+ *
+ * @param {import("./interface.mjs").HarnessItem[]} items
+ * @returns {Record<string, number>}
+ */
+export function buildCounts(items) {
+  const counts = { total: items.length };
+  for (const item of items) {
+    counts[item.category] = (counts[item.category] || 0) + 1;
+  }
+  return counts;
+}
+
+function descriptorFor(adapter) {
+  return {
+    id: adapter.id,
+    displayName: adapter.displayName,
+    shortName: adapter.shortName,
+    icon: adapter.icon,
+    executable: adapter.executable,
+  };
+}
+
+function splitExtras(extras = {}) {
+  const {
+    effective = null,
+    notices = [],
+    adapterData = {},
+    ...rest
+  } = extras || {};
+
+  return {
+    effective,
+    notices,
+    adapterData: { ...rest, ...adapterData },
+  };
+}
+
+/**
+ * Assemble a stable ScanResult shape for UI/API consumers.
+ *
+ * @param {import("./interface.mjs").HarnessAdapter} adapter
+ * @param {import("./interface.mjs").HarnessScope[]} scopes
+ * @param {import("./interface.mjs").HarnessItem[]} items
+ * @param {Record<string, *>} [extras]
+ * @returns {import("./interface.mjs").ScanResult}
+ */
+export function normalizeScanResult(adapter, scopes, items, extras = {}) {
+  const normalizedExtras = splitExtras(extras);
+
+  return {
+    harness: descriptorFor(adapter),
+    categories: adapter.categories,
+    scopeTypes: adapter.scopeTypes,
+    capabilities: adapter.capabilities,
+    scopes,
+    items,
+    counts: buildCounts(items),
+    effective: normalizedExtras.effective,
+    notices: normalizedExtras.notices,
+    adapterData: normalizedExtras.adapterData,
+  };
+}
+
+async function runScopeScanners(adapter, scope, ctx) {
+  const categoryScans = Object.entries(adapter.scanners).map(async ([categoryId, scanner]) => {
+    const items = await scanner(scope, ctx);
+    if (!Array.isArray(items)) {
+      throw new TypeError(`Scanner ${adapter.id}.${categoryId} must return an array`);
+    }
+    return items;
+  });
+
+  return (await Promise.all(categoryScans)).flat();
+}
+
+/**
+ * Run all scanners exposed by a harness adapter.
+ *
+ * @param {import("./interface.mjs").HarnessAdapter} adapter
+ * @param {Record<string, *>} [options]
+ * @returns {Promise<import("./interface.mjs").ScanResult>}
+ */
+export async function scanHarness(adapter, options = {}) {
+  validateAdapter(adapter);
+
+  const ctx = createHarnessContext(adapter, options);
+  await adapter.beforeScan?.(ctx);
+
+  const scopes = await adapter.discoverScopes(ctx);
+  if (!Array.isArray(scopes)) {
+    throw new TypeError(`Adapter ${adapter.id} discoverScopes(ctx) must return an array`);
+  }
+
+  const scopedItems = (await Promise.all(
+    scopes.map(scope => runScopeScanners(adapter, scope, ctx))
+  )).flat();
+
+  const globalItems = adapter.scanGlobalItems
+    ? await adapter.scanGlobalItems(ctx)
+    : [];
+  if (!Array.isArray(globalItems)) {
+    throw new TypeError(`Adapter ${adapter.id} scanGlobalItems(ctx) must return an array`);
+  }
+
+  const items = [...scopedItems, ...globalItems];
+  const partialResult = normalizeScanResult(adapter, scopes, items);
+  const extras = await adapter.afterScan?.(ctx, partialResult);
+
+  if (extras && typeof extras !== "object") {
+    throw new TypeError(`Adapter ${adapter.id} afterScan(ctx, result) must return an object or undefined`);
+  }
+
+  return extras === undefined
+    ? partialResult
+    : normalizeScanResult(adapter, scopes, items, extras);
+}


### PR DESCRIPTION
## Summary
- Add harness adapter interface contract with full type definitions (`src/harness/interface.mjs`)
- Extract shared filesystem helpers used by scanners (`src/harness/fs-utils.mjs`)
- Add generic scan orchestration framework that runs any adapter's scanners (`src/harness/scanner-framework.mjs`)
- Add adapter registry with lazy-loading from `src/harness/adapters/` (`src/harness/registry.mjs`)

This is **foundation only** — no existing code modified, zero regression risk. Phase 2 will extract the Claude adapter from current scanner.mjs using this interface.

## Test plan
- [x] All 4 new files pass `node --check` syntax validation
- [x] Correct exports verified via dynamic import
- [x] All 200 existing E2E tests pass (5.3m runtime)
- [x] Server module imports cleanly
- [x] No existing files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex CLI](https://github.com/openai/codex)