### PR TITLE
fix: restore Claude path, plugin skill, and preview scanning

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mcp": "node src/mcp-server.mjs",
     "test": "npx playwright test --config tests/e2e/playwright.config.mjs",
     "test:headed": "npx playwright test --config tests/e2e/playwright.config.mjs --headed",
-    "test:unit": "node --test tests/unit/"
+    "test:unit": "node --test tests/unit/*.mjs"
   },
   "keywords": [
     "claude-code",

--- a/src/harness/adapters/claude.mjs
+++ b/src/harness/adapters/claude.mjs
@@ -180,6 +180,115 @@ function resetSettingsCache() {
 // ── Path decoding ────────────────────────────────────────────────────
 
 /**
+ * Ground-truth resolver: read a session file inside the encoded project dir
+ * and pull the `cwd` field from an entry. Claude Code writes the real cwd into
+ * sessions, so this avoids guessing when path encoding is lossy.
+ */
+async function resolveViaSessionCwd(claudeProjectDir) {
+  let entries;
+  try {
+    entries = await readdir(claudeProjectDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const sessionFiles = entries
+    .filter(e => e.isFile() && e.name.endsWith(".jsonl"))
+    .slice(0, 3);
+
+  for (const entry of sessionFiles) {
+    const lines = await readFirstLines(join(claudeProjectDir, entry.name), 20);
+    for (const line of lines) {
+      const cwd = parseJsonLine(line)?.cwd;
+      if (typeof cwd === "string" && cwd.length > 0 && await exists(cwd)) return cwd;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Character-level fallback for encoded paths containing Unicode characters.
+ * Claude Code preserves alphanumerics and hyphens, and encodes everything else
+ * as "-". Treat encoded "-" as a non-alphanumeric wildcard.
+ */
+async function resolveEncodedProjectPathUnicode(encoded) {
+  let pattern = encoded.replace(/^-/, "");
+  let rootPath = "/";
+
+  if (RUNTIME_PLATFORM === "win32" && /^[a-z]--/i.test(pattern)) {
+    rootPath = pattern[0].toUpperCase() + ":\\";
+    pattern = pattern.slice(3);
+  }
+
+  const alnum = /[A-Za-z0-9]/;
+
+  async function walk(currentPath, pos) {
+    if (pos >= pattern.length) {
+      return (await exists(currentPath)) ? currentPath : null;
+    }
+
+    let entries;
+    try {
+      entries = (await readdir(currentPath, { withFileTypes: true }))
+        .filter(e => e.isDirectory() || e.isSymbolicLink())
+        .map(e => e.name);
+    } catch {
+      return null;
+    }
+
+    const candidates = [];
+    for (const name of entries) {
+      if (pos + name.length > pattern.length) continue;
+
+      let ok = true;
+      for (let i = 0; i < name.length; i++) {
+        const pc = pattern[pos + i];
+        const nc = name[i];
+        if (pc === "-") {
+          if (alnum.test(nc)) {
+            ok = false;
+            break;
+          }
+        } else if (pc.toLowerCase() !== nc.toLowerCase()) {
+          ok = false;
+          break;
+        }
+      }
+      if (!ok) continue;
+
+      const nextPos = pos + name.length;
+      if (nextPos === pattern.length) {
+        candidates.push({ name, nextPos });
+      } else if (pattern[nextPos] === "-") {
+        candidates.push({ name, nextPos: nextPos + 1 });
+      }
+    }
+
+    candidates.sort((a, b) => b.name.length - a.name.length);
+    for (const candidate of candidates) {
+      const result = await walk(join(currentPath, candidate.name), candidate.nextPos);
+      if (result) return result;
+    }
+
+    return null;
+  }
+
+  return walk(rootPath, 0);
+}
+
+function prettifyEncodedPath(encoded) {
+  let cleaned = encoded.replace(/^-/, "");
+  if (/^[a-z]--/i.test(cleaned)) {
+    cleaned = cleaned[0].toUpperCase() + ":/" + cleaned.slice(3);
+  }
+  cleaned = cleaned.replace(/-{2,}/g, "/.../");
+  cleaned = cleaned.replace(/-/g, "/");
+  cleaned = cleaned.replace(/\/+/g, "/").replace(/^\/|\/$/g, "");
+  return cleaned || encoded;
+}
+
+/**
  * Resolve an encoded project dir name back to a real filesystem path.
  * E.g. "-home-user-mycompany-repo1" → "/home/user/mycompany/repo1"
  *
@@ -214,7 +323,7 @@ async function resolveEncodedProjectPath(encoded) {
     let entries;
     try {
       entries = await readdir(currentPath, { withFileTypes: true });
-      entries = entries.filter(e => e.isDirectory());
+      entries = entries.filter(e => e.isDirectory() || e.isSymbolicLink());
     } catch {
       return null;
     }
@@ -276,38 +385,48 @@ async function discoverScopes() {
   for (const d of projectDirs) {
     if (!d.isDirectory()) continue;
 
-    // Decode encoded path: try to find the real directory on disk.
-    // The encoding replaces / with - and prepends -.
-    // E.g. -home-user-mycompany-repo1 → /home/user/mycompany/repo1
-    // Since directory names can contain dashes, we resolve by checking which real path exists.
-    const realPath = await resolveEncodedProjectPath(d.name);
-    if (!realPath) continue;
-
-    const shortName = basename(realPath);
     const projectDir = join(projectsDir, d.name);
 
     // Discover any project directory that has content (not just memory).
     // Sessions, plans, or other items may exist without a memory/ subfolder.
     const entries = await readdir(projectDir);
     const hasContent = entries.some(e => e !== ".DS_Store");
+    if (!hasContent) continue;
 
-    if (hasContent) {
-      projectEntries.push({
-        encodedName: d.name,
-        realPath,
-        shortName,
-        claudeProjectDir: projectDir,
-      });
-    }
+    let realPath = await resolveViaSessionCwd(projectDir);
+    if (!realPath) realPath = await resolveEncodedProjectPath(d.name);
+    if (!realPath) realPath = await resolveEncodedProjectPathUnicode(d.name);
+
+    projectEntries.push({
+      encodedName: d.name,
+      realPath,
+      shortName: realPath ? basename(realPath) : prettifyEncodedPath(d.name),
+      claudeProjectDir: projectDir,
+    });
   }
 
-  // Sort by path depth (shorter = parent) then alphabetically
+  // Sort by path depth (shorter = parent) then alphabetically. Unresolved
+  // encoded scopes are kept last so their memory/session content stays visible.
   projectEntries.sort((a, b) => {
+    if (!a.realPath && !b.realPath) return a.shortName.localeCompare(b.shortName);
+    if (!a.realPath) return 1;
+    if (!b.realPath) return -1;
     const da = a.realPath.split("/").length;
     const db = b.realPath.split("/").length;
     if (da !== db) return da - db;
     return a.realPath.localeCompare(b.realPath);
   });
+
+  const nameCount = new Map();
+  for (const entry of projectEntries) {
+    nameCount.set(entry.shortName, (nameCount.get(entry.shortName) || 0) + 1);
+  }
+  for (const entry of projectEntries) {
+    if (entry.realPath && nameCount.get(entry.shortName) > 1) {
+      const parts = entry.realPath.split(/[\/\\]/).filter(Boolean);
+      if (parts.length >= 2) entry.shortName = `${parts.at(-2)}/${entry.shortName}`;
+    }
+  }
 
   // Claude Code has two scopes: User (global) and Project.
   // Every project's parent is always global — there is no intermediate workspace scope.
@@ -369,6 +488,10 @@ async function loadSkillBundles(repoDir) {
 
 // ── Item scanners ────────────────────────────────────────────────────
 
+function encodeClaudeProjectName(realPath) {
+  return realPath.replace(/[^A-Za-z0-9-]/g, "-");
+}
+
 async function scanMemories(scope) {
   const items = [];
   const settings = await getSettingsOverrides();
@@ -429,6 +552,64 @@ async function scanSkills(scope) {
   // Load bundle info from skills-lock.json
   const bundleMap = await loadSkillBundles(scope.repoDir);
 
+  async function readSkillEntry(skillsRoot, entryName, pluginName = null) {
+    const skillDir = join(skillsRoot, entryName);
+    const skillMd = join(skillDir, "SKILL.md");
+    if (!(await exists(skillMd))) return null;
+
+    const s = await safeStat(skillMd);
+    const content = await safeReadFile(skillMd);
+
+    // Extract description: first meaningful paragraph line after the heading
+    let description = "";
+    if (content) {
+      const lines = content.split("\n");
+      let pastHeading = false;
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith("# ")) { pastHeading = true; continue; }
+        if (!pastHeading) continue;
+        // Skip empty lines, frontmatter-like lines, code blocks, list items
+        if (!trimmed) continue;
+        if (trimmed.startsWith("```") || trimmed.startsWith("-") || trimmed.startsWith("|")) continue;
+        if (trimmed.match(/^\w+:\s/)) continue; // skip "name: foo" style lines
+        if (trimmed.startsWith("##")) continue;
+        description = trimmed.slice(0, 120);
+        break;
+      }
+    }
+
+    // Count files in skill directory
+    const allFiles = await readdir(skillDir, { withFileTypes: true });
+    const fileCount = allFiles.filter(f => f.isFile()).length;
+
+    // Total size of skill directory
+    let totalSize = 0;
+    for (const f of allFiles.filter(f => f.isFile())) {
+      const fs = await safeStat(join(skillDir, f.name));
+      if (fs) totalSize += fs.size;
+    }
+
+    // Bundle detection from skills-lock.json
+    const bundleInfo = bundleMap.get(entryName);
+
+    return {
+      category: "skill",
+      scopeId: scope.id,
+      name: entryName,
+      fileName: entryName, // directory name
+      description,
+      subType: pluginName ? "plugin-skill" : "skill",
+      size: formatSize(totalSize),
+      sizeBytes: totalSize,
+      fileCount,
+      mtime: s ? s.mtime.toISOString().slice(0, 16) : "",
+      ctime: s ? s.birthtime.toISOString().slice(0, 16) : "",
+      path: skillDir,
+      bundle: pluginName || bundleInfo?.source || null,
+    };
+  }
+
   for (const skillsRoot of skillDirs) {
     const entries = await readdir(skillsRoot, { withFileTypes: true });
     for (const entry of entries) {
@@ -437,61 +618,49 @@ async function scanSkills(scope) {
       // Skip "private" directory (usually copies of global skills)
       if (entry.name === "private") continue;
 
-      const skillDir = join(skillsRoot, entry.name);
-      const skillMd = join(skillDir, "SKILL.md");
-      if (!(await exists(skillMd))) continue;
+      const item = await readSkillEntry(skillsRoot, entry.name);
+      if (item) items.push(item);
+    }
+  }
 
-      const s = await safeStat(skillMd);
-      const content = await safeReadFile(skillMd);
+  const installedPluginsFile = join(CLAUDE_DIR, "plugins", "installed_plugins.json");
+  const installedContent = await safeReadFile(installedPluginsFile);
+  if (installedContent) {
+    let installedData;
+    try { installedData = JSON.parse(installedContent); } catch { installedData = null; }
 
-      // Extract description: first meaningful paragraph line after the heading
-      let description = "";
-      if (content) {
-        const lines = content.split("\n");
-        let pastHeading = false;
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (trimmed.startsWith("# ")) { pastHeading = true; continue; }
-          if (!pastHeading) continue;
-          // Skip empty lines, frontmatter-like lines, code blocks, list items
-          if (!trimmed) continue;
-          if (trimmed.startsWith("```") || trimmed.startsWith("-") || trimmed.startsWith("|")) continue;
-          if (trimmed.match(/^\w+:\s/)) continue; // skip "name: foo" style lines
-          if (trimmed.startsWith("##")) continue;
-          description = trimmed.slice(0, 120);
-          break;
+    for (const [pluginName, installs] of Object.entries(installedData?.plugins || {})) {
+      for (const install of installs || []) {
+        const isUserScope = install.scope === "user";
+        const isProjectScope = install.scope === "project" && install.projectPath;
+
+        let belongs = false;
+        if (scope.id === "global" && isUserScope) {
+          belongs = true;
+        } else if (scope.type === "project" && isProjectScope) {
+          const pluginEncoded = encodeClaudeProjectName(install.projectPath);
+          belongs = pluginEncoded === scope.id ||
+            Boolean(scope.repoDir && install.projectPath.toLowerCase() === scope.repoDir.toLowerCase());
+        }
+        if (!belongs || !install.installPath) continue;
+
+        const pluginSkillsDir = join(install.installPath, "skills");
+        if (!(await exists(pluginSkillsDir))) continue;
+
+        let entries;
+        try {
+          entries = await readdir(pluginSkillsDir, { withFileTypes: true });
+        } catch {
+          continue;
+        }
+
+        for (const entry of entries) {
+          if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+          if (entry.name === "private") continue;
+          const item = await readSkillEntry(pluginSkillsDir, entry.name, pluginName);
+          if (item) items.push(item);
         }
       }
-
-      // Count files in skill directory
-      const allFiles = await readdir(skillDir, { withFileTypes: true });
-      const fileCount = allFiles.filter(f => f.isFile()).length;
-
-      // Total size of skill directory
-      let totalSize = 0;
-      for (const f of allFiles.filter(f => f.isFile())) {
-        const fs = await safeStat(join(skillDir, f.name));
-        if (fs) totalSize += fs.size;
-      }
-
-      // Bundle detection from skills-lock.json
-      const bundleInfo = bundleMap.get(entry.name);
-
-      items.push({
-        category: "skill",
-        scopeId: scope.id,
-        name: entry.name,
-        fileName: entry.name, // directory name
-        description,
-        subType: "skill",
-        size: formatSize(totalSize),
-        sizeBytes: totalSize,
-        fileCount,
-        mtime: s ? s.mtime.toISOString().slice(0, 16) : "",
-        ctime: s ? s.birthtime.toISOString().slice(0, 16) : "",
-        path: skillDir,
-        bundle: bundleInfo?.source || null,
-      });
     }
   }
 

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -3725,9 +3725,12 @@ function renderMarkdown(text) {
   if (!text) return "";
   // Strip YAML frontmatter
   let content = text.replace(/^---\n[\s\S]*?\n---\n?/, "").trim();
-  // Fallback if marked CDN failed to load
-  if (typeof marked === "undefined") return `<pre>${esc(content)}</pre>`;
-  return marked.parse(content);
+  try {
+    if (typeof marked === "undefined") return `<pre>${esc(content)}</pre>`;
+    if (typeof marked.parse === "function") return marked.parse(content);
+    if (typeof marked === "function") return marked(content);
+  } catch {}
+  return `<pre>${esc(content)}</pre>`;
 }
 
 // ── MCP Policy Panel ──────────────────────────────────────────────

--- a/tests/e2e/dashboard.spec.mjs
+++ b/tests/e2e/dashboard.spec.mjs
@@ -16,7 +16,7 @@ import { test, expect } from '@playwright/test';
 import { spawn } from 'node:child_process';
 import {
   mkdtemp, mkdir, writeFile, readFile, access,
-  rm, readdir, stat,
+  rm, readdir, stat, chmod,
 } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -69,6 +69,8 @@ async function createTestEnv() {
   const port = PORT_COUNTER++;
   const tmpDir = await mkdtemp(join(tmpdir(), 'cco-test-'));
   const claudeDir = join(tmpDir, '.claude');
+  const binDir = join(tmpDir, 'bin');
+  const claudeBin = join(binDir, 'claude');
 
   // ── Directory structure ──
   const dirs = {
@@ -92,6 +94,7 @@ async function createTestEnv() {
 
   // Create all directories (including real repo dirs for path resolution)
   await Promise.all([
+    mkdir(binDir, { recursive: true }),
     mkdir(dirs.globalMem, { recursive: true }),
     mkdir(dirs.globalSkills, { recursive: true }),
     mkdir(dirs.projectMem, { recursive: true }),
@@ -102,6 +105,9 @@ async function createTestEnv() {
     mkdir(nestedDir, { recursive: true }),
     mkdir(deepDir, { recursive: true }),
   ]);
+
+  await writeFile(claudeBin, '#!/bin/sh\necho CCO_AUTH_OK\n');
+  await chmod(claudeBin, 0o755);
 
   // ── Global memories (4 types) ──
   const globalMemories = {
@@ -274,7 +280,7 @@ async function createTestEnv() {
   let actualPort = port;
   const server = await new Promise((resolve, reject) => {
     const proc = spawn(NODE_BIN, [join(PROJECT_ROOT, 'bin', 'cli.mjs'), '--port', String(port), '--no-open'], {
-      env: { ...process.env, HOME: tmpDir },
+      env: { ...process.env, HOME: tmpDir, PATH: `${binDir}:${process.env.PATH}` },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
@@ -1092,6 +1098,34 @@ test.describe('UI Rendering', () => {
     await page.click('#detailClose');
   });
 
+  test('detail panel previews markdown-backed skills, memories, and agents even if markdown parser fails', async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window, 'marked', {
+        configurable: true,
+        value: { parse: () => { throw new Error('marked failed'); } },
+      });
+    });
+
+    await page.goto(env.baseURL);
+    await page.waitForSelector('#loading', { state: 'hidden' });
+    await page.locator('.s-scope-hdr[data-scope-id="global"] .s-nm').click();
+    await page.waitForTimeout(300);
+
+    const cases = [
+      { name: 'deploy', expected: 'Deploy the application to production.' },
+      { name: 'user_prefs', expected: 'TypeScript + ESM' },
+      { name: 'code-reviewer', expected: 'Review code carefully.' },
+    ];
+
+    for (const { name, expected } of cases) {
+      const row = page.locator('.item', { hasText: name }).first();
+      await expect(row).toBeVisible();
+      await row.click();
+      await expect(page.locator('#previewContent')).toContainText(expected);
+      await expect(page.locator('#previewContent')).not.toContainText('Failed to load preview');
+    }
+  });
+
   test('move modal shows full scope hierarchy with current scope marked', async ({ page }) => {
     await page.goto(env.baseURL);
     await page.waitForSelector('#loading', { state: 'hidden' });
@@ -1828,31 +1862,31 @@ test.describe('Security — malformed input', () => {
   test.beforeAll(async () => { env = await createTestEnv(); });
   test.afterAll(async () => { await env.cleanup(); });
 
-  test('POST /api/move with invalid JSON returns 500', async () => {
+  test('POST /api/move with invalid JSON returns 400', async () => {
     const res = await fetch(`${env.baseURL}/api/move`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: 'this is not json{{{',
     });
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
   });
 
-  test('POST /api/delete with invalid JSON returns 500', async () => {
+  test('POST /api/delete with invalid JSON returns 400', async () => {
     const res = await fetch(`${env.baseURL}/api/delete`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '{"broken',
     });
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
   });
 
-  test('POST /api/restore with empty body returns 500', async () => {
+  test('POST /api/restore with empty body returns 400', async () => {
     const res = await fetch(`${env.baseURL}/api/restore`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '',
     });
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
   });
 
   test('POST /api/move with empty object returns 400', async () => {
@@ -2848,12 +2882,16 @@ test.describe('Security Scanner API', () => {
   });
 
   test('GET /api/security-status returns availability', async () => {
+    test.setTimeout(45000);
     const env = await createTestEnv();
-    const res = await fetch(`${env.baseURL}/api/security-status`);
-    const data = await res.json();
-    expect(data.ok).toBe(true);
-    expect(typeof data.available).toBe('boolean');
-    env.cleanup();
+    try {
+      const res = await fetch(`${env.baseURL}/api/security-status`);
+      const data = await res.json();
+      expect(data.ok).toBe(true);
+      expect(typeof data.available).toBe('boolean');
+    } finally {
+      await env.cleanup();
+    }
   });
 
   test('POST+GET /api/security-cache round-trip', async () => {

--- a/tests/unit/test-claude-adapter-regressions.mjs
+++ b/tests/unit/test-claude-adapter-regressions.mjs
@@ -1,0 +1,134 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { scanHarness } from '../../src/harness/scanner-framework.mjs';
+import { claudeAdapter } from '../../src/harness/adapters/claude.mjs';
+
+function encodeClaudeProjectName(realPath) {
+  return realPath.replace(/[^A-Za-z0-9-]/g, '-');
+}
+
+async function createClaudeHome(prefix = 'cco-claude-regression-') {
+  const home = await mkdtemp(join(tmpdir(), prefix));
+  await mkdir(join(home, '.claude', 'projects'), { recursive: true });
+  return {
+    home,
+    async cleanup() {
+      await rm(home, { recursive: true, force: true });
+    },
+  };
+}
+
+async function createProjectScope(home, repoDir, encodedName = encodeClaudeProjectName(repoDir)) {
+  await mkdir(repoDir, { recursive: true });
+  const claudeProjectDir = join(home, '.claude', 'projects', encodedName);
+  await mkdir(claudeProjectDir, { recursive: true });
+  await writeFile(join(claudeProjectDir, 'session.jsonl'), JSON.stringify({ cwd: repoDir, type: 'user' }) + '\n');
+  return { encodedName, claudeProjectDir };
+}
+
+async function createSkill(root, name, heading = name) {
+  await mkdir(join(root, name), { recursive: true });
+  await writeFile(join(root, name, 'SKILL.md'), `# ${heading}\n\nUse this test skill.\n`);
+}
+
+describe('Claude adapter regressions from scanner PRs', () => {
+  it('scans user and project plugin-provided skills from installed_plugins.json', async () => {
+    const env = await createClaudeHome();
+    try {
+      const repoDir = join(env.home, 'work', 'demo-repo');
+      await createProjectScope(env.home, repoDir);
+
+      const userPlugin = join(env.home, '.claude', 'plugins', 'cache', 'market', 'user-plugin', '1.0.0');
+      const projectPlugin = join(env.home, '.claude', 'plugins', 'cache', 'market', 'project-plugin', '1.0.0');
+      await createSkill(join(userPlugin, 'skills'), 'global-plugin-skill', 'Global Plugin Skill');
+      await createSkill(join(projectPlugin, 'skills'), 'project-plugin-skill', 'Project Plugin Skill');
+
+      await writeFile(join(env.home, '.claude', 'plugins', 'installed_plugins.json'), JSON.stringify({
+        plugins: {
+          'user-plugin@market': [
+            { scope: 'user', installPath: userPlugin },
+          ],
+          'project-plugin@market': [
+            { scope: 'project', projectPath: repoDir, installPath: projectPlugin },
+          ],
+        },
+      }, null, 2));
+
+      const result = await scanHarness(claudeAdapter, { home: env.home, cwd: repoDir, platform: 'darwin' });
+      const projectScope = result.scopes.find(scope => scope.repoDir === repoDir);
+      assert.ok(projectScope, 'project scope should be discovered');
+
+      assert.ok(result.items.some(item =>
+        item.category === 'skill' &&
+        item.scopeId === 'global' &&
+        item.name === 'global-plugin-skill' &&
+        item.subType === 'plugin-skill' &&
+        item.bundle === 'user-plugin@market'
+      ));
+      assert.ok(result.items.some(item =>
+        item.category === 'skill' &&
+        item.scopeId === projectScope.id &&
+        item.name === 'project-plugin-skill' &&
+        item.subType === 'plugin-skill' &&
+        item.bundle === 'project-plugin@market'
+      ));
+    } finally {
+      await env.cleanup();
+    }
+  });
+
+  it('keeps unresolved encoded project scopes so memories and sessions stay visible', async () => {
+    const env = await createClaudeHome();
+    try {
+      const encodedName = '-missing-project-with-memory';
+      const claudeProjectDir = join(env.home, '.claude', 'projects', encodedName);
+      await mkdir(join(claudeProjectDir, 'memory'), { recursive: true });
+      await writeFile(join(claudeProjectDir, 'memory', 'note.md'), `---
+name: Unresolved Note
+description: Still visible without repoDir
+---
+# Note
+`);
+      await writeFile(join(claudeProjectDir, 'session.jsonl'), JSON.stringify({ type: 'user', message: 'hello' }) + '\n');
+
+      const result = await scanHarness(claudeAdapter, { home: env.home, cwd: env.home, platform: 'darwin' });
+      const unresolvedScope = result.scopes.find(scope => scope.id === encodedName);
+
+      assert.ok(unresolvedScope, 'unresolved encoded project should still appear');
+      assert.strictEqual(unresolvedScope.repoDir, null);
+      assert.ok(result.items.some(item =>
+        item.category === 'memory' &&
+        item.scopeId === encodedName &&
+        item.name === 'Unresolved Note'
+      ));
+      assert.ok(result.items.some(item =>
+        item.category === 'session' &&
+        item.scopeId === encodedName
+      ));
+    } finally {
+      await env.cleanup();
+    }
+  });
+
+  it('resolves encoded paths that traverse symlinked directories', async () => {
+    const env = await createClaudeHome();
+    try {
+      const targetRoot = join(env.home, 'actual-root');
+      const linkedRoot = join(env.home, 'linked-root');
+      await mkdir(join(targetRoot, 'demo-repo'), { recursive: true });
+      await symlink(targetRoot, linkedRoot, 'dir');
+
+      const repoDir = join(linkedRoot, 'demo-repo');
+      await createProjectScope(env.home, repoDir);
+
+      const result = await scanHarness(claudeAdapter, { home: env.home, cwd: repoDir, platform: 'darwin' });
+
+      assert.ok(result.scopes.some(scope => scope.repoDir === repoDir), 'scope should resolve through symlink path');
+    } finally {
+      await env.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- port the useful bug fixes from #20/#21 onto the current Claude harness adapter
- resolve Claude project scopes through session cwd, symlink traversal, Unicode/lossy encoded paths, and keep unresolved scopes visible
- scan Claude plugin-provided skills for user and project scopes
- make markdown-backed previews fall back to escaped text when marked fails, so skills/memories/agents do not show Failed to load preview
- stabilize e2e coverage for malformed JSON and security-status auth checks

## Tests
- npm run test:unit
- npm test

Ken review: no comments.